### PR TITLE
fix: short divider has parent

### DIFF
--- a/src/components/Divider/Schema.js
+++ b/src/components/Divider/Schema.js
@@ -135,6 +135,7 @@ export const DividerEditSchema = ({ intl }) => ({
 export const DividerStylingSchema = (props) => {
   const schema = addStyling(props);
   const { intl } = props;
+
   schema.properties.styles.schema = {
     title: intl.formatMessage(messages.Type),
     block: 'divider',

--- a/src/components/Divider/View.jsx
+++ b/src/components/Divider/View.jsx
@@ -3,15 +3,34 @@ import cx from 'classnames';
 import { Divider } from 'semantic-ui-react';
 import './divider.less';
 
-export default ({ data }) => (
-  <Divider
-    hidden={data.hidden}
-    section={data.section}
-    fitted={data.fitted}
-    className={cx(data.styles?.theme, data.short ? 'short' : '')}
-    horizontal={!!data.text}
-    inverted={data.styles?.inverted}
-  >
-    {data.text ? <div>{data.text}</div> : ''}
-  </Divider>
-);
+export default ({ data }) => {
+  return (
+    <>
+      {!data?.styles || Object.keys(data.styles).length === 0 ? (
+        <div className="styled-dividerBlock">
+          <Divider
+            hidden={data.hidden}
+            section={data.section}
+            fitted={data.fitted}
+            className={cx(data.styles?.theme, data.short ? 'short' : '')}
+            horizontal={!!data.text}
+            inverted={data.styles?.inverted}
+          >
+            {data.text ? <div>{data.text}</div> : ''}
+          </Divider>
+        </div>
+      ) : (
+        <Divider
+          hidden={data.hidden}
+          section={data.section}
+          fitted={data.fitted}
+          className={cx(data.styles?.theme, data.short ? 'short' : '')}
+          horizontal={!!data.text}
+          inverted={data.styles?.inverted}
+        >
+          {data.text ? <div>{data.text}</div> : ''}
+        </Divider>
+      )}
+    </>
+  );
+};

--- a/src/components/Divider/View.jsx
+++ b/src/components/Divider/View.jsx
@@ -4,32 +4,27 @@ import { Divider } from 'semantic-ui-react';
 import './divider.less';
 
 export default ({ data }) => {
+  const DividerRender = ({ data }) => (
+    <Divider
+      hidden={data.hidden}
+      section={data.section}
+      fitted={data.fitted}
+      className={cx(data.styles?.theme, data.short ? 'short' : '')}
+      horizontal={!!data.text}
+      inverted={data.styles?.inverted}
+    >
+      {data.text ? <div>{data.text}</div> : ''}
+    </Divider>
+  );
+
   return (
     <>
-      {!data?.styles || Object.keys(data.styles).length === 0 ? (
+      {!data?.styles?.theme ? (
         <div className="styled-dividerBlock">
-          <Divider
-            hidden={data.hidden}
-            section={data.section}
-            fitted={data.fitted}
-            className={cx(data.styles?.theme, data.short ? 'short' : '')}
-            horizontal={!!data.text}
-            inverted={data.styles?.inverted}
-          >
-            {data.text ? <div>{data.text}</div> : ''}
-          </Divider>
+          <DividerRender data={data} />
         </div>
       ) : (
-        <Divider
-          hidden={data.hidden}
-          section={data.section}
-          fitted={data.fitted}
-          className={cx(data.styles?.theme, data.short ? 'short' : '')}
-          horizontal={!!data.text}
-          inverted={data.styles?.inverted}
-        >
-          {data.text ? <div>{data.text}</div> : ''}
-        </Divider>
+        <DividerRender data={data} />
       )}
     </>
   );


### PR DESCRIPTION
Unstyled divider block has a parent div. 

Useful for cases where short divider that has Primary, Secondary has a different size than a short divider with no style. 

![image](https://user-images.githubusercontent.com/44702393/230104845-c754fdcb-86d6-4ab5-ab48-f5e7231669c0.png)
Last 2 dividers are short but have a different width in this picture ^^ 